### PR TITLE
Optimize API logging middleware

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -7,30 +7,34 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
 app.use((req, res, next) => {
-  const start = Date.now();
   const path = req.path;
-  let capturedJsonResponse: Record<string, any> | undefined = undefined;
 
-  const originalResJson = res.json;
-  res.json = function (bodyJson, ...args) {
+  // Only wrap the response and log when handling API routes
+  if (!path.startsWith("/api")) {
+    return next();
+  }
+
+  const start = Date.now();
+  let capturedJsonResponse: Record<string, any> | undefined;
+
+  const originalResJson = res.json.bind(res);
+  res.json = (bodyJson, ...args) => {
     capturedJsonResponse = bodyJson;
-    return originalResJson.apply(res, [bodyJson, ...args]);
+    return originalResJson(bodyJson, ...args);
   };
 
   res.on("finish", () => {
     const duration = Date.now() - start;
-    if (path.startsWith("/api")) {
-      let logLine = `${req.method} ${path} ${res.statusCode} in ${duration}ms`;
-      if (capturedJsonResponse) {
-        logLine += ` :: ${JSON.stringify(capturedJsonResponse)}`;
-      }
-
-      if (logLine.length > 80) {
-        logLine = logLine.slice(0, 79) + "…";
-      }
-
-      log(logLine);
+    let logLine = `${req.method} ${path} ${res.statusCode} in ${duration}ms`;
+    if (capturedJsonResponse) {
+      logLine += ` :: ${JSON.stringify(capturedJsonResponse)}`;
     }
+
+    if (logLine.length > 80) {
+      logLine = logLine.slice(0, 79) + "…";
+    }
+
+    log(logLine);
   });
 
   next();


### PR DESCRIPTION
## Summary
- wrap API logging middleware only for `/api` routes to avoid intercepting non-API responses

## Testing
- `npx vitest run`
- `npm run check` *(fails: Property 'description' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_6894d43759e8832a8b38462968262682